### PR TITLE
refactor: remove unused include and improve error message in parse_ve…

### DIFF
--- a/src/parse/parse_utils.c
+++ b/src/parse/parse_utils.c
@@ -1,5 +1,4 @@
 #include "libft.h"
-#include "scene.h"
 #include "object.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -85,6 +84,7 @@ int	parse_vec3(char *line, double vec[3])
 		n++;
 	if (n != 3)
 	{
+		printf("Vector parsing error: expected 3 components, got %d\n", n);
 		ft_free_tab(tab);
 		return (1);
 	}


### PR DESCRIPTION
This pull request makes a minor update to the vector parsing utility function to improve error reporting and cleans up an unused include.

- Error handling improvement:
  * Added a descriptive error message to `parse_vec3` to indicate when the parsed vector does not have exactly three components.

- Code cleanup:
  * Removed an unused `#include "scene.h"` directive from `parse_utils.c`.…c3 function