### PR TITLE
refactor: improve error handling for empty scene file in check_parse_…

### DIFF
--- a/src/parse/parse.c
+++ b/src/parse/parse.c
@@ -72,7 +72,13 @@ int	check_parse_file(int fd, t_scene *scene)
 	char	*token;
 	int		obj_type;
 
-	while ((line = get_next_line(fd)))
+	line = get_next_line(fd);
+	if (!line)
+	{
+		printf("Error: Empty scene file\n");
+		return (1);
+	}
+	while (line)
 	{
 		trimmed = ft_strtrim(line, " \t\r\n");
 		p = trimmed;
@@ -101,6 +107,8 @@ int	check_parse_file(int fd, t_scene *scene)
 			free(token);
 		}
 		free(trimmed);
+		line = get_next_line(fd);
 	}
+	free(line);
 	return (0);
 }


### PR DESCRIPTION
…file function
This pull request improves error handling and memory management in the `check_parse_file` function in `src/parse/parse.c`. The changes ensure that empty scene files are detected early and that all allocated memory for lines is properly freed.

Error handling improvements:

* Added a check for empty scene files at the start of parsing, printing an error message and returning early if the file is empty.

Memory management improvements:

* Ensured that the `line` buffer is freed after the parsing loop to prevent memory leaks.