### PR TITLE
fix: add ft_atoi_checked function and integrate it for color parsing …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ MINILIBX_DIR = minilibx/
 # -------------------------------
 
 SRCS = main.c parse/parse.c parse/parse_utils.c parse/ambient.c \
-parse/camera.c parse/light.c \
+parse/camera.c parse/light.c parse/ft_atoi_checked.c \
 parse/sphere.c parse/plane.c parse/cylinder.c parse/validate_range.c \
 vector.c ray.c camera.c \
 debug_print_scene.c mlx_utils.c \

--- a/include/parse.h
+++ b/include/parse.h
@@ -22,6 +22,7 @@ int							parse_plane(char *line, t_scene *scene);
 int							parse_cylinder(char *line, t_scene *scene);
 int							validate_input_range(t_scene *scene);
 void						ft_free_tab(char **tab);
+int							ft_atoi_checked(const char *nptr, int *num);
 char						*get_token(char **str, const char *delim);
 
 #endif

--- a/src/parse/ambient.c
+++ b/src/parse/ambient.c
@@ -1,7 +1,6 @@
 #include "libft.h"
 #include "parse.h"
 #include <stdio.h>
-#include <stdlib.h>
 
 int	parse_ratio(char *str, double *ratio)
 {

--- a/src/parse/ft_atoi_checked.c
+++ b/src/parse/ft_atoi_checked.c
@@ -1,0 +1,44 @@
+#include "libft.h"
+#include <limits.h>
+
+static const char	*skip_spaces_and_sign(const char *nptr, int *sign)
+{
+	while ((*nptr >= 9 && *nptr <= 13) || *nptr == ' ')
+		nptr++;
+	if (*nptr == '-' || *nptr == '+')
+	{
+		if (*nptr == '-')
+			*sign *= -1;
+		nptr++;
+	}
+	while (*nptr == '0' && *(nptr + 1) != '\0')
+		nptr++;
+	return (nptr);
+}
+
+int	ft_atoi_checked(const char *nptr, int *num)
+{
+	long	res;
+	int		sign;
+	int		digit_found;
+
+	res = 0;
+	sign = 1;
+	digit_found = 0;
+	nptr = skip_spaces_and_sign(nptr, &sign);
+	if (ft_strlen(nptr) > 11)
+		return (1);
+	while (*nptr >= '0' && *nptr <= '9')
+	{
+		digit_found = 1;
+		res = (res * 10) + (*nptr - '0');
+		nptr++;
+	}
+	if (!digit_found || *nptr != '\0')
+		return (1);
+	res *= sign;
+	if (res > INT_MAX || res < INT_MIN)
+		return (1);
+	*num = (int)res;
+	return (0);
+}

--- a/src/parse/parse_utils.c
+++ b/src/parse/parse_utils.c
@@ -2,6 +2,7 @@
 #include "object.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include "parse.h"
 
 char	*get_token(char **str, const char *delim)
 {
@@ -64,7 +65,12 @@ int	parse_color(char *line, int color[3])
 	i = 0;
 	while (i < 3)
 	{
-		color[i] = ft_atoi(tab[i]);
+		if (ft_atoi_checked(tab[i], &color[i]) || color[i] < 0 || color[i] > 255)
+		{
+			printf("Color parsing error: invalid value '%s'\n", tab[i]);
+			ft_free_tab(tab);
+			return (1);
+		}
 		i++;
 	}
 	ft_free_tab(tab);


### PR DESCRIPTION
…validation
This pull request introduces improved input validation for color parsing and adds a new utility function for safe integer conversion. The main focus is on preventing invalid or out-of-range values from being accepted when parsing color data, which enhances the robustness of the parsing logic.

**Input validation improvements:**

* Added a new function `ft_atoi_checked` that safely converts strings to integers, checking for invalid input and integer overflow/underflow. [[1]](diffhunk://#diff-f8eef92067f705f9a09678cdcfaf4373bfee0622a8bf362deed70e784d88b111R1-R44) [[2]](diffhunk://#diff-ac37dec209fa8bb954d22b65af684b212380a8d3a6f18a2ab5bb9699319a235eR25) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L25-R25)
* Updated `parse_color` in `parse_utils.c` to use `ft_atoi_checked` and reject invalid or out-of-range color values, printing an error message when encountered.

**Codebase organization:**

* Included the new `parse/ft_atoi_checked.c` source file in the build process.
* Added the necessary header include for `parse.h` in `parse_utils.c` to ensure access to the new function.

**Minor cleanup:**

* Removed an unnecessary `#include <stdlib.h>` from `ambient.c`.