### PR TITLE
fix: add validation for zero-length camera orientation vector

### DIFF
--- a/src/parse/validate_range.c
+++ b/src/parse/validate_range.c
@@ -65,6 +65,11 @@ int	validate_camera_orientation_range(t_scene *scene)
 		printf("Error: Camera orientation component out of range (-1.0 - 1.0)\n");
 		return (1);
 	}
+	if (vector3_length(ori) == 0.0)
+	{
+		printf("Error: Camera orientation vector cannot be zero\n");
+		return (1);
+	}
 	return (0);
 }
 


### PR DESCRIPTION
This pull request adds an additional validation check to the camera orientation logic to prevent invalid input. Now, the code ensures that the camera orientation vector is not the zero vector, which would be invalid for defining a direction.

Validation improvements:

* Added a check in `validate_camera_orientation_range` (in `src/parse/validate_range.c`) to ensure the camera orientation vector is not the zero vector, displaying an error message if it is.