### PR TITLE
fix: enhance ambient ratio parsing by rejecting trailing junk characters

### DIFF
--- a/src/parse/ambient.c
+++ b/src/parse/ambient.c
@@ -13,6 +13,11 @@ int	parse_ratio(char *str, double *ratio)
 		printf("Error\nInvalid double value for ambient ratio\n");
 		return (1);
 	}
+	// Reject any trailing junk characters after the numeric part
+	if (*endptr != '\0') 
+	{
+		return (1);
+	}
 	*ratio = value;
 	return (0);
 }


### PR DESCRIPTION
This pull request makes a small but important improvement to the ambient ratio parsing logic by adding stricter validation for input strings.

* Parsing validation: The function `parse_ratio` in `src/parse/ambient.c` now rejects any input that contains trailing non-numeric characters after the valid double value, ensuring only properly formatted ratios are accepted.