### PR TITLE
fix: Handle ft_strtrim failure

### DIFF
--- a/src/parse/parse.c
+++ b/src/parse/parse.c
@@ -81,6 +81,12 @@ int	check_parse_file(int fd, t_scene *scene)
 	while (line)
 	{
 		trimmed = ft_strtrim(line, " \t\r\n");
+		if (!trimmed)
+		{
+			printf("Error\nMemory allocation failed\n");
+			free(line);
+			return (1);
+		}
 		p = trimmed;
 		free(line);
 		token = get_token(&p, " ");


### PR DESCRIPTION
This pull request introduces an error handling improvement in the `check_parse_file` function within `src/parse/parse.c`. The change ensures that the program gracefully handles memory allocation failures when trimming lines during file parsing.

Error handling enhancement:

* Added a check for a failed memory allocation after calling `ft_strtrim`, printing an error message and returning early if allocation fails. (`src/parse/parse.c`, [src/parse/parse.cR84-R89](diffhunk://#diff-e716bdbc74b7dcbddbe2b62422700f83e997206ebb5415fb070665cd90aa36a4R84-R89))