### PR TITLE
fix: Remove extra flags -g and -g3 from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 NAME = miniRT
 CC = cc
-CFLAGS = -Wall -Wextra -Werror -g3 -g
+CFLAGS = -Wall -Wextra -Werror
 MINILIBX_FLAGS = -L$(MINILIBX_DIR) -lmlx -lXext -lX11 -lm -lz
 
 # -------------------------------


### PR DESCRIPTION
This pull request makes a small change to the build configuration by updating the compiler flags in the `Makefile`. The debug flags `-g3 -g` have been removed from `CFLAGS`, so the code will now be compiled without debug information.