### PR TITLE
feat: Add function prototypes for cylinder diameter and height parsing

### DIFF
--- a/include/parse.h
+++ b/include/parse.h
@@ -20,6 +20,8 @@ int							parse_light(char *line, t_scene *scene);
 int							parse_sphere(char *line, t_scene *scene);
 int							parse_plane(char *line, t_scene *scene);
 int							parse_cylinder(char *line, t_scene *scene);
+int							parse_cylinder_diameter(char **tab, double *diameter);
+int							parse_cylinder_height(char **tab, double *height);
 int							validate_input_range(t_scene *scene);
 void						ft_free_tab(char **tab);
 int							ft_atoi_checked(const char *nptr, int *num);


### PR DESCRIPTION
This pull request introduces two new functions to the parsing interface for cylinders, allowing for more modular parsing of cylinder diameter and height from input data.

Parsing improvements for cylinders:

* Added `parse_cylinder_diameter` and `parse_cylinder_height` functions to `include/parse.h` to separately handle parsing of cylinder diameter and height from tokenized input.