### PR TITLE
fix: parse diameter and height correctly

### DIFF
--- a/src/parse/parse_cylinder.c
+++ b/src/parse/parse_cylinder.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/28 17:46:44 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/12/01 21:01:45 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/12/02 18:23:23 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,9 +74,6 @@ static int	parse_cylinder_components(char **tab, double *tmp_center,
 		ft_free_tab(tab);
 		return (1);
 	}
-	if (parse_cylinder_diameter(tab, &tmp_center[3])
-		|| parse_cylinder_height(tab, &tmp_center[4]))
-		return (1);
 	return (0);
 }
 
@@ -105,6 +102,9 @@ int	parse_cylinder(char *line, t_scene *scene)
 		return (1);
 	}
 	fill_cylinder_values(&cy, tmp_center, tmp_ori, tmp_color);
+	if (parse_cylinder_diameter(tab, &cy.diameter)
+		|| parse_cylinder_height(tab, &cy.height))
+		return (1);
 	if (cylinder_init(&cy, cy.center, cy.orientation, cy.diameter, cy.height,
 			material_from_rgb8(cy.color)) || push_cylinder(scene, &cy))
 	{


### PR DESCRIPTION
This pull request refactors the parsing logic for cylinder objects to ensure that diameter and height parsing occurs after the main cylinder values are filled, rather than during component parsing. This change clarifies the parsing flow and ensures that all necessary values are available before diameter and height are parsed.

Parsing logic improvements:

* Moved the calls to `parse_cylinder_diameter` and `parse_cylinder_height` from the `parse_cylinder_components` function to after the `fill_cylinder_values` call in the main `parse_cylinder` function, ensuring these fields are parsed at the correct stage of the process. [[1]](diffhunk://#diff-b43d6e36eed90824ce26d2e31090832c7cf659c2dd35c54db0f54cbd9923f68dL77-L79) [[2]](diffhunk://#diff-b43d6e36eed90824ce26d2e31090832c7cf659c2dd35c54db0f54cbd9923f68dR105-R107)